### PR TITLE
[법규] FAQ관리

### DIFF
--- a/Monstarbooks/src/main/java/com/monstar/books/adfaq/controller/AdFaqController.java
+++ b/Monstarbooks/src/main/java/com/monstar/books/adfaq/controller/AdFaqController.java
@@ -12,6 +12,7 @@ import com.monstar.books.adfaq.service.AdFaqDeleteServiceList;
 import com.monstar.books.adfaq.service.AdFaqDetailServiceList;
 import com.monstar.books.adfaq.service.AdFaqInsertServiceList;
 import com.monstar.books.adfaq.service.AdFaqService;
+import com.monstar.books.adfaq.service.AdFaqServiceList;
 import com.monstar.books.adfaq.service.AdFaqServiceList1;
 import com.monstar.books.adfaq.service.AdFaqServiceList2;
 import com.monstar.books.adfaq.service.AdFaqServiceList3;
@@ -25,16 +26,28 @@ public class AdFaqController {
 	@Autowired
 	private SqlSession sqlSession;
 	
-	// faq1	, 카테고리가 반품/교환/환불인 FAQ 조회
+	// faq	, 전체 FAQ 조회
 	@RequestMapping("admin/adfaq/faq")
 	public String Faq(Model model) {
 		
+		System.out.println("=== FAQ ===");
+
+		adfaqService = new AdFaqServiceList(sqlSession);
+		adfaqService.execute(model);
+		
+		return "admin/adfaq/faq";
+	}
+	
+	// faq1	, 카테고리가 반품/교환/환불인 FAQ 조회
+	@RequestMapping("admin/adfaq/faq1")
+	public String Faq1(Model model) {
 		System.out.println("=== FAQ1 ===");
 		
 		adfaqService = new AdFaqServiceList1(sqlSession);
 		adfaqService.execute(model);
 		
 		return "admin/adfaq/faq";
+		
 	}
 	
 	// faq2 , 카테고리가 주문취소/변경인 FAQ 조회
@@ -80,6 +93,8 @@ public class AdFaqController {
 	// faqUpdate
 	@RequestMapping("admin/adfaq/faqUpdate")
 	public String FaqUpdate(HttpServletRequest request, Model model) {
+		System.out.println("=== faqUpdate ===");
+		
 		model.addAttribute("request",request);
 		adfaqService = new AdFaqDetailServiceList(sqlSession);
 		adfaqService.execute(model);

--- a/Monstarbooks/src/main/java/com/monstar/books/adfaq/dao/AdFaqDao.java
+++ b/Monstarbooks/src/main/java/com/monstar/books/adfaq/dao/AdFaqDao.java
@@ -7,6 +7,7 @@ import com.monstar.books.adfaq.dto.AdFaqDto;
 public interface AdFaqDao {
 	
 	// faqList
+	public ArrayList<AdFaqDto> faqListAll();	// 전체 FAQ 리스트 조회
 	public ArrayList<AdFaqDto> faqList1();		// 반품/교환/환불
 	public ArrayList<AdFaqDto> faqList2();		// 주문취소/변경
 	public ArrayList<AdFaqDto> faqList3();		// 배송/수령일 안내

--- a/Monstarbooks/src/main/java/com/monstar/books/adfaq/service/AdFaqDeleteServiceList.java
+++ b/Monstarbooks/src/main/java/com/monstar/books/adfaq/service/AdFaqDeleteServiceList.java
@@ -19,10 +19,13 @@ public class AdFaqDeleteServiceList implements AdFaqService {
 
 	@Override
 	public void execute(Model model) {
+		System.out.println(">>> AdFaqDeleteServiceList");
+		
 		Map<String, Object> map = model.asMap();
 		HttpServletRequest request = (HttpServletRequest) map.get("request");
 		
 		String faqno = request.getParameter("faqno");
+		System.out.println("faqno : " + faqno);
 		
 		AdFaqDao dao = sqlSession.getMapper(AdFaqDao.class);
 		dao.faqDelete(faqno);

--- a/Monstarbooks/src/main/java/com/monstar/books/adfaq/service/AdFaqDetailServiceList.java
+++ b/Monstarbooks/src/main/java/com/monstar/books/adfaq/service/AdFaqDetailServiceList.java
@@ -23,7 +23,24 @@ public class AdFaqDetailServiceList implements AdFaqService {
 		HttpServletRequest request = (HttpServletRequest) map.get("request");
 		
 		String faqno = request.getParameter("faqno");
+		String fcategory = request.getParameter("fcategory");
 		AdFaqDao dao = sqlSession.getMapper(AdFaqDao.class);
+		
+		
+		if(fcategory != null) {
+			if(fcategory.equals("반품/교환/환불")) {
+				String fcategory1 = fcategory;
+//				System.out.println("fcategory1 : " + fcategory1);		// 반품/교환/환불
+				model.addAttribute("fcategory1","true");
+			}else if(fcategory.equals("주문취소/변경")) {
+				String fcategory2 = fcategory;
+				model.addAttribute("fcategory2","true");
+			}else if(fcategory.equals("배송/수령일 안내")) {
+				String fcategory3 = fcategory;
+				model.addAttribute("fcategory3","true");
+			}
+		}
+		
 		
 		AdFaqDto dto = dao.faqDetail(faqno);
 		model.addAttribute("faqDetail",dto);

--- a/Monstarbooks/src/main/java/com/monstar/books/adfaq/service/AdFaqServiceList.java
+++ b/Monstarbooks/src/main/java/com/monstar/books/adfaq/service/AdFaqServiceList.java
@@ -1,0 +1,25 @@
+package com.monstar.books.adfaq.service;
+
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.ui.Model;
+
+import com.monstar.books.adfaq.dao.AdFaqDao;
+
+public class AdFaqServiceList implements AdFaqService {
+	
+	private SqlSession sqlSession;
+	
+	public AdFaqServiceList(SqlSession sqlSession) {
+		this.sqlSession=sqlSession;
+	}
+
+	@Override
+	public void execute(Model model) {
+		System.out.println(">>> AdFaqServiceList");
+		
+		AdFaqDao dao = sqlSession.getMapper(AdFaqDao.class);
+		model.addAttribute("faq",dao.faqListAll());
+		
+	}
+
+}

--- a/Monstarbooks/src/main/java/com/monstar/books/adfaq/service/AdFaqUpdateServiceList.java
+++ b/Monstarbooks/src/main/java/com/monstar/books/adfaq/service/AdFaqUpdateServiceList.java
@@ -28,13 +28,15 @@ public class AdFaqUpdateServiceList implements AdFaqService {
 		String fquestion = request.getParameter("fquestion");
 		String fanswer = request.getParameter("fanswer");
 		String fcategory = request.getParameter("fcategory");
+		AdFaqDao dao = sqlSession.getMapper(AdFaqDao.class);
+		
+		
 		
 		System.out.println("faqno : " + faqno);
 		System.out.println("fquestion : " + fquestion);
 		System.out.println("fanswer : " + fanswer);
 		System.out.println("fcategory : " + fcategory);
 		
-		AdFaqDao dao = sqlSession.getMapper(AdFaqDao.class);
 		dao.faqUpdate(faqno,fquestion,fanswer,fcategory);
 		
 		

--- a/Monstarbooks/src/main/java/com/monstar/books/mapper/AdFaqMapper.xml
+++ b/Monstarbooks/src/main/java/com/monstar/books/mapper/AdFaqMapper.xml
@@ -4,6 +4,11 @@
     
     <mapper namespace="com.monstar.books.adfaq.dao.AdFaqDao">
     
+    <!-- 전체 FAQ 리스트를 불러오는 쿼리 -->
+    <select id="faqListAll" resultType="com.monstar.books.adfaq.dto.AdFaqDto">
+    	SELECT * FROM M_FAQ ORDER BY FAQNO DESC
+    </select>
+    
     <!-- FAQ 반품/교환/환불 리스트를 불러오는 쿼리 -->
     <select id="faqList1" resultType="com.monstar.books.adfaq.dto.AdFaqDto">
     	SELECT * FROM M_FAQ WHERE FCATEGORY='반품/교환/환불' ORDER BY FAQNO DESC

--- a/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adfaq/faq.jsp
+++ b/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adfaq/faq.jsp
@@ -8,6 +8,7 @@
 <title>몬스타북:FAQ</title>
 
 <script>
+	// onclick
 	function check_faqInsert(){
 		if(confirm("FAQ를 등록하시겠습니까?")){
 			location.href = "./faqInsert";
@@ -17,7 +18,7 @@
 	}
 	
 	function select_fcategory1(){
-		location.href = "faq";
+		location.href = "faq1";
 	}
 	
 	function select_fcategory2(){
@@ -28,8 +29,17 @@
 		location.href = "faq3";
 	}
 	
-	
+	function check_faqDelete(i){
+		if(confirm("FAQ를 삭제하시겠습니까?")){
+			location.href = "faqDelete?faqno=" + i;
+			alert("FAQ가 삭제되었습니다");
+			return;
+		}else {
+			return;
+		}
+	}
 </script>
+
 </head>
 <body>
 <h2>FAQ</h2>
@@ -42,29 +52,28 @@
 
 <button onclick="check_faqInsert();">등록</button>
 
-<div>
-	<ul>
-		<c:forEach items="${faq }" var="faq">
-		
-			<li>
-			<!-- 질문 -->
-				<div class="faq_question">
-					<h3>${faq.fquestion }</h3>
-					<!-- 수정을 하겠냐고 되묻는 팝업창 생성 해야 함 -->
-					<button><a href="faqUpdate?faqno=${faq.faqno }">수정</a></button>
-					<!-- 삭제를 하겠냐고 되묻는 팝업창 생성해야 함 -->
-					<button><a href="faqDelete?faqno=${faq.faqno }">삭제</a></button>
-				</div>
+	<!-- 아코디언 메뉴 -->
+	<div>
+		<ul>
+			<c:forEach items="${faq }" var="faq">
+				<li>
+					<!-- 질문 -->
+					<div>
+						<h3>Q. ${faq.fquestion }</h3>
+						<a href="faqUpdate?faqno=${faq.faqno }&fcategory=${faq.fcategory}">수정</a>
+						<button onclick="check_faqDelete(${faq.faqno});">삭제</button>
+						<button type="button">펼치기</button>
+					</div>
 				
-			<!-- 답변 -->
-				<div class="faq_answer">
-					<p>${faq.fanswer }</p>
-				</div>
-			</li>
-			
-		</c:forEach>
-	</ul>
-</div>
+					<!-- 답변 -->
+					<div>
+						<p>A. ${faq.fanswer }</p>
+					</div>
+				</li>
+			</c:forEach>			
+		</ul>
+	</div>
 	
 </body>
 </html>
+

--- a/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adfaq/faqInsert.jsp
+++ b/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adfaq/faqInsert.jsp
@@ -10,11 +10,11 @@
 		var frm = document.insertFaq;
 		
 		if(frm.fquestion.value == ""){
-			alert("질문을 작성해주세요");
+			alert("질문을 입력해주세요");
 			frm.fquestion.focus();
 			return false;
 		}else if(frm.fanswer.value == ""){
-			alert("답변을 작성해주세요");
+			alert("답변을 입력해주세요");
 			frm.fanswer.focus();
 			return false;
 		}else if(confirm("FAQ를 등록하시겠습니까?")){

--- a/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adfaq/faqUpdate.jsp
+++ b/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adfaq/faqUpdate.jsp
@@ -34,8 +34,7 @@
 		}else {
 			return;
 		}
-	}	
-	
+	}		
 	
 </script>
 </head>
@@ -46,13 +45,40 @@
 	<input type="hidden" name="faqno" value="${faqDetail.faqno }" />
 		Question. <br />
 		
-		<!-- 드롭다운 중복값 제거 못했음 / 해야함 -->
+		<!-- 드롭다운 -->
 		<select name="fcategory">
-			<option value="${faqDetail.fcategory }" selected>${faqDetail.fcategory }</option>
-			<option id="fcategory1" value="반품/교환/환불">반품/교환/환불</option>
-			<option id="fcategory2" value="주문취소/변경">주문취소/변경</option>
-			<option id="fcategory3" value="배송/수령일 안내">배송/수령일 안내</option>
+		
+			<!-- 수정할 FAQ의 카테고리가 반품/교환/환불인 경우 -->
+			<c:choose>
+				<c:when test="${fcategory1 }">
+					<option id="fcategory1" value="반품/교환/환불" selected>반품/교환/환불</option>
+				</c:when>
+				<c:otherwise>
+					<option id="fcategory1" value="반품/교환/환불">반품/교환/환불</option>
+				</c:otherwise>
+			</c:choose>
+			
+			<!-- 수정할 FAQ의 카테고리가 주문취소/변경인 경우 -->
+			<c:choose>
+				<c:when test="${fcategory2 }">
+					<option id="fcategory2" value="주문취소/변경" selected>주문취소/변경</option>
+				</c:when>
+				<c:otherwise>
+					<option id="fcategory2" value="주문취소/변경">주문취소/변경</option>
+				</c:otherwise>
+			</c:choose>
+			
+			<!-- 수정할 FAQ의 카테고리가 배송/수령일 안내인 경우 -->
+			<c:choose>
+				<c:when test="${fcategory3 }">
+					<option id="fcategory3" value="배송/수령일 안내" selected>배송/수령일 안내</option>
+				</c:when>
+				<c:otherwise>
+					<option id="fcategory3" value="배송/수령일 안내">배송/수령일 안내</option>
+				</c:otherwise>
+			</c:choose>			
 		</select> <br />
+		
 		
 		<textarea type="text" name="fquestion" rows="10" cols="70" maxlength="500"
 		style="resize: none;">${faqDetail.fquestion }</textarea> <br /><br /><br />

--- a/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adnotice/noticeDetail.jsp
+++ b/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adnotice/noticeDetail.jsp
@@ -7,6 +7,7 @@
 <meta charset="UTF-8">
 <title>공지 상세</title>
 <script>
+
 	function updateNotice(){
 		if(confirm("공지를 수정하시겠습니까?")){
 			location.href = "./noticeUpdate?noticeno=${noticeDetail.noticeno }";

--- a/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adnotice/noticeDetail.jsp
+++ b/Monstarbooks/src/main/webapp/WEB-INF/views/admin/adnotice/noticeDetail.jsp
@@ -15,13 +15,15 @@
 		}
 	}
 	
-	function deleteNotice(){
+	function deleteNotice(i){
 		if(confirm("공지를 삭제하시겠습니까?")){
-			location.href = "./delete?noticeno=${noticenoDetail.noticeno}";
+			location.href = "delete?noticeno=" + i;
+			alert("공지가 삭제되었습니다");
 		}else {
 			return;
 		}
 	}
+	
 </script>
 </head>
 <body>
@@ -72,7 +74,7 @@
 		</tr>
 	</table>
 	
-	<button onclick="deleteNotice();">삭제</button>
+	<button onclick="deleteNotice(${noticeDetail.noticeno});">삭제</button>
 	
 		
 </body>


### PR DESCRIPTION
- 첫화면은 FAQ 전체 리스트가 나오게끔 하는 기능 추가
- 수정 시 기존 FAQ의 카테고리를 수정 페이지의 카테고리에 유지시키는 기능 추가
- FAQ리스트에서 삭제 버튼 클릭시 , 삭제하겠냐고 되묻는 alert창 기능 추가
- 아코디언 메뉴 및 css 제외 전부했습니다